### PR TITLE
Change BrowserRouter to HashRouter

### DIFF
--- a/src/js/components/Router.js
+++ b/src/js/components/Router.js
@@ -4,7 +4,7 @@ import "../../css/Router.css"
 // js
 // react-router-dom
 import React, { useReducer } from 'react';
-import { BrowserRouter, Switch, Route } from "react-router-dom";
+import { HashRouter, Switch, Route } from "react-router-dom";
 // components
 import NavHeader from "./NavHeader";
 import Footer from "./Footer";
@@ -74,11 +74,10 @@ function Router() {
 
   return (
     <>
-      <BrowserRouter>
+      <HashRouter>
         <CartContext.Provider value={cart}>
           <CartDispatch.Provider value={dispatch}>
           <NavHeader />
-          <React.StrictMode>
             <main className="App content">
               <Switch>
                 <Route exact path="/" component={Home} />
@@ -88,11 +87,10 @@ function Router() {
                 <Route component={NotFound} />
               </Switch>
             </main>
-            </React.StrictMode>
           </CartDispatch.Provider>
         </CartContext.Provider>
         <Footer />
-      </BrowserRouter>
+      </HashRouter>
     </>
   );
 }


### PR DESCRIPTION
Just learnt that BrowserRouter is meant for applications with a back-end, otherwise it needlessly sends requests to the server. Instead, with a HashRouter, the URL gets a hash appended to denote a front-end route -- the browser (client) should process and interpret this instead.

For hosting on Github Pages, you need to use a HashRouter otherwise the pathing gets all messed up (sends request to root of the user's github pages site instead of the subfolder directory, resulting in 404 on Github's Page).